### PR TITLE
Fixed (ILSpy) submodule issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "ILSpy"]
 	path = decompiler/ILSpy
 	url = https://github.com/icsharpcode/ILSpy.git
-	branch = master
 [submodule "proto-extractor/proto-extractor"]
 	path = proto-extractor/proto-extractor
 	url = https://github.com/HearthSim/proto-extractor

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "ILSpy"]
 	path = decompiler/ILSpy
-	url = https://github.com/HearthSim/ILSpy.git
+	url = https://github.com/icsharpcode/ILSpy.git
+	branch = master
 [submodule "proto-extractor/proto-extractor"]
 	path = proto-extractor/proto-extractor
 	url = https://github.com/HearthSim/proto-extractor


### PR DESCRIPTION
This fixes the submodule still being linked to the ILSpy forked repo. This repo now properly clones without errors.
(includes commithash for latest proto-extractor master commit, which includes enum name fix and indentation misalignment fix)

I suppose the fact that there were no problems (on buildbox) meant that all problems were locally fixed, but that was never pushed to remote?

Fix was tested by performing a clone with branch checkout.
No other reasons to await merging this PR, unless local repo on buildbox has more/other stuff fixed which can be pushed.